### PR TITLE
v0.8.0: Added markdown support, and more contextual data to the readability scores

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alexneri/readability-ts",
   "description": "A CLI app that runs the Flesch-kincaid readability score recursively on all *.adoc files in the current directory.",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "readability-ts": "node readability.js"


### PR DESCRIPTION
* Added more information in the scores.txt file: File length: <total number of code lines>, Sentence count: <total sentences in the file>, Word count: <total words>, Average word length: <average of the letters per word in the file>, Average syllables: <average number of syllables per word>, Code present: <yes or no, if there is a code block present in the file>, Acronyms: <the number of acronyms used in the file>.
* Added the same information to the comment that is added per file.
* Added support for *.md files and markdown formatted-docs. *Bumped version to 0.8.0