### PR TITLE
Add --version and --whats-new CLI flags; refresh --help

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -97,12 +97,25 @@ For the full license text see: GNU GPL v3
 
 A donation is not required, but it is appreciated. If you find this program useful, please consider [sponsoring](https://github.com/sponsors/alexneri) me :) 
 
+## Development
+
+Run the test suite (Node 18+; no extra devDependencies required):
+
+```
+npm test
+```
+
+Tests live in `test/` and use Node's built-in `node:test` runner. They
+cover both the pure scoring/parsing functions and the CLI flags via
+child-process integration tests.
+
 ## Roadmap
 
 * ~~Make this installable on npm~~ **DONE**
 * ~~Add Markdown support with proper comment syntax~~ **DONE**
 * ~~Idempotent re-runs~~ **DONE**
 * ~~Skip vendored/build directories by default~~ **DONE**
+* ~~Add a basic test suite~~ **DONE**
 * Add more tests
 * Add more documentation
 * Add more supported file formats

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ readability-ts [path] [options]
 
 * `path` — folder to scan (defaults to the current working directory).
 * `-n`, `--dry-run` — compute scores without modifying any files or writing `scores.txt`.
+* `-v`, `--version` — print the installed version and exit.
+* `-rn`, `--whats-new`, `--release-notes` — print release notes for the current version and exit.
 * `-h`, `--help` — show usage.
 
 ### Examples
@@ -63,6 +65,9 @@ readability-ts [path] [options]
 readability-ts                 # scan the current folder
 readability-ts ./docs          # scan a specific folder
 readability-ts ./docs -n       # preview scores without writing anything
+readability-ts --version       # print the installed version
+readability-ts --whats-new     # print release notes for the current version
+readability-ts --help          # print usage
 ```
 
 ### Re-running

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "description": "A CLI app that runs the Flesch-Kincaid readability score recursively on AsciiDoc and Markdown files.",
   "version": "0.9.0",
   "scripts": {
-    "build": "tsc",
-    "prepublishOnly": "tsc && npm test",
+    "build": "tsc && node -e \"require('fs').chmodSync('readability.js', 0o755)\"",
+    "prepublishOnly": "npm run build && npm test",
     "test": "node --test test/*.test.js",
     "readability-ts": "node readability.js"
   },
@@ -42,6 +42,9 @@
     "url": "https://github.com/alexneri/readability-folder-ts/issues"
   },
   "homepage": "https://readability-cli.sei.moe/",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@types/node": "^22.9.1",
     "typescript": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.9.0",
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "tsc",
+    "prepublishOnly": "tsc && npm test",
+    "test": "node --test test/*.test.js",
     "readability-ts": "node readability.js"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "bugs": {
     "url": "https://github.com/alexneri/readability-folder-ts/issues"
   },
-  "homepage": "https://github.com/alexneri/readability-folder-ts",
+  "homepage": "https://readability-cli.sei.moe/",
   "devDependencies": {
     "@types/node": "^22.9.1",
     "typescript": "^4.0.0"

--- a/readability.js
+++ b/readability.js
@@ -37,6 +37,26 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const fs = __importStar(require("fs/promises"));
 const path = __importStar(require("path"));
 const perf_hooks_1 = require("perf_hooks");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkg = require('./package.json');
+const VERSION = pkg.version;
+const RELEASE_NOTES = `What's new in readability-ts v${VERSION}
+
+* Idempotent re-runs: existing readability headers are detected via
+  readability-score:start / readability-score:end sentinels and replaced
+  in place, so re-running the tool no longer stacks duplicate headers.
+* Legacy headers written by pre-0.9 versions are auto-migrated on the
+  next run.
+* Added --dry-run (-n): compute scores without modifying files or
+  writing scores.txt.
+* Added --version (-v) and --whats-new (--release-notes, -rn).
+* Default-skip vendored and build directories: node_modules, .git,
+  dist, build, out, .next, .nuxt, .cache, coverage, .idea, .vscode.
+* Concurrent processing (8 files at a time) and a TTY progress bar.
+
+For the full changelog see:
+https://github.com/alexneri/readability-folder-ts/commits/main
+`;
 const SUPPORTED_EXTENSIONS = new Map([
     ['.adoc', 'asciidoc'],
     ['.asciidoc', 'asciidoc'],
@@ -285,25 +305,50 @@ function parseArgs(argv) {
     const args = argv.slice(2);
     const dryRun = args.includes('--dry-run') || args.includes('-n');
     const help = args.includes('--help') || args.includes('-h');
+    const version = args.includes('--version') || args.includes('-v');
+    const whatsNew = args.includes('--whats-new')
+        || args.includes('--release-notes')
+        || args.includes('-rn');
     const positional = args.filter(a => !a.startsWith('-'));
     const folderPath = positional[0] || process.cwd();
-    return { folderPath, dryRun, help };
+    return { folderPath, dryRun, help, version, whatsNew };
 }
 function printHelp() {
     console.log('Usage: readability-ts [path] [options]\n\n' +
         'Computes Flesch-Kincaid readability scores for AsciiDoc and Markdown files.\n\n' +
         'Arguments:\n' +
-        '  path           Folder to scan (defaults to current directory)\n\n' +
+        '  path                          Folder to scan (defaults to current directory)\n\n' +
         'Options:\n' +
-        '  -n, --dry-run  Compute scores without modifying files or writing scores.txt\n' +
-        '  -h, --help     Show this message\n\n' +
-        'Supported extensions: .adoc, .asciidoc, .md, .markdown, .mdx');
+        '  -n,  --dry-run                Compute scores without modifying files or writing scores.txt\n' +
+        '  -v,  --version                Print the installed version and exit\n' +
+        '  -rn, --whats-new,\n' +
+        '       --release-notes          Print release notes for the current version and exit\n' +
+        '  -h,  --help                   Show this message and exit\n\n' +
+        'Supported extensions: .adoc, .asciidoc, .md, .markdown, .mdx\n\n' +
+        'Examples:\n' +
+        '  readability-ts                Scan the current folder\n' +
+        '  readability-ts ./docs         Scan a specific folder\n' +
+        '  readability-ts ./docs -n      Preview scores without writing anything');
+}
+function printVersion() {
+    console.log(`readability-ts v${VERSION}`);
+}
+function printWhatsNew() {
+    console.log(RELEASE_NOTES);
 }
 async function main() {
     const start = perf_hooks_1.performance.now();
-    const { folderPath, dryRun, help } = parseArgs(process.argv);
+    const { folderPath, dryRun, help, version, whatsNew } = parseArgs(process.argv);
     if (help) {
         printHelp();
+        return;
+    }
+    if (version) {
+        printVersion();
+        return;
+    }
+    if (whatsNew) {
+        printWhatsNew();
         return;
     }
     try {

--- a/readability.js
+++ b/readability.js
@@ -40,6 +40,7 @@ const perf_hooks_1 = require("perf_hooks");
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkg = require('./package.json');
 const VERSION = pkg.version;
+const HOMEPAGE = pkg.homepage;
 const RELEASE_NOTES = `What's new in readability-ts v${VERSION}
 
 * Idempotent re-runs: existing readability headers are detected via
@@ -56,7 +57,7 @@ const RELEASE_NOTES = `What's new in readability-ts v${VERSION}
 
 For the full changelog see:
 https://github.com/alexneri/readability-folder-ts/commits/main
-`;
+${HOMEPAGE ? `\nFind out more: ${HOMEPAGE}\n` : ''}`;
 const SUPPORTED_EXTENSIONS = new Map([
     ['.adoc', 'asciidoc'],
     ['.asciidoc', 'asciidoc'],

--- a/readability.js
+++ b/readability.js
@@ -34,14 +34,30 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.RELEASE_NOTES = exports.HOMEPAGE = exports.VERSION = void 0;
+exports.detectFormat = detectFormat;
+exports.countSyllables = countSyllables;
+exports.tokenize = tokenize;
+exports.fleschKincaid = fleschKincaid;
+exports.getRating = getRating;
+exports.stripExistingHeader = stripExistingHeader;
+exports.stripLegacyHeader = stripLegacyHeader;
+exports.stripMarkdown = stripMarkdown;
+exports.stripAsciidoc = stripAsciidoc;
+exports.countAcronyms = countAcronyms;
+exports.formatHeader = formatHeader;
+exports.parseArgs = parseArgs;
+exports.printHelp = printHelp;
+exports.printVersion = printVersion;
+exports.printWhatsNew = printWhatsNew;
 const fs = __importStar(require("fs/promises"));
 const path = __importStar(require("path"));
 const perf_hooks_1 = require("perf_hooks");
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkg = require('./package.json');
-const VERSION = pkg.version;
-const HOMEPAGE = pkg.homepage;
-const RELEASE_NOTES = `What's new in readability-ts v${VERSION}
+exports.VERSION = pkg.version;
+exports.HOMEPAGE = pkg.homepage;
+exports.RELEASE_NOTES = `What's new in readability-ts v${exports.VERSION}
 
 * Idempotent re-runs: existing readability headers are detected via
   readability-score:start / readability-score:end sentinels and replaced
@@ -57,7 +73,7 @@ const RELEASE_NOTES = `What's new in readability-ts v${VERSION}
 
 For the full changelog see:
 https://github.com/alexneri/readability-folder-ts/commits/main
-${HOMEPAGE ? `\nFind out more: ${HOMEPAGE}\n` : ''}`;
+${exports.HOMEPAGE ? `\nFind out more: ${exports.HOMEPAGE}\n` : ''}`;
 const SUPPORTED_EXTENSIONS = new Map([
     ['.adoc', 'asciidoc'],
     ['.asciidoc', 'asciidoc'],
@@ -332,10 +348,10 @@ function printHelp() {
         '  readability-ts ./docs -n      Preview scores without writing anything');
 }
 function printVersion() {
-    console.log(`readability-ts v${VERSION}`);
+    console.log(`readability-ts v${exports.VERSION}`);
 }
 function printWhatsNew() {
-    console.log(RELEASE_NOTES);
+    console.log(exports.RELEASE_NOTES);
 }
 async function main() {
     const start = perf_hooks_1.performance.now();
@@ -388,4 +404,6 @@ async function main() {
         process.exit(1);
     }
 }
-void main();
+if (require.main === module) {
+    void main();
+}

--- a/readability.ts
+++ b/readability.ts
@@ -5,8 +5,9 @@ import * as path from 'path';
 import { performance } from 'perf_hooks';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const pkg = require('./package.json') as { version: string };
+const pkg = require('./package.json') as { version: string; homepage?: string };
 const VERSION: string = pkg.version;
+const HOMEPAGE: string | undefined = pkg.homepage;
 
 const RELEASE_NOTES = `What's new in readability-ts v${VERSION}
 
@@ -24,7 +25,7 @@ const RELEASE_NOTES = `What's new in readability-ts v${VERSION}
 
 For the full changelog see:
 https://github.com/alexneri/readability-folder-ts/commits/main
-`;
+${HOMEPAGE ? `\nFind out more: ${HOMEPAGE}\n` : ''}`;
 
 type FileFormat = 'asciidoc' | 'markdown';
 

--- a/readability.ts
+++ b/readability.ts
@@ -6,10 +6,10 @@ import { performance } from 'perf_hooks';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkg = require('./package.json') as { version: string; homepage?: string };
-const VERSION: string = pkg.version;
-const HOMEPAGE: string | undefined = pkg.homepage;
+export const VERSION: string = pkg.version;
+export const HOMEPAGE: string | undefined = pkg.homepage;
 
-const RELEASE_NOTES = `What's new in readability-ts v${VERSION}
+export const RELEASE_NOTES = `What's new in readability-ts v${VERSION}
 
 * Idempotent re-runs: existing readability headers are detected via
   readability-score:start / readability-score:end sentinels and replaced
@@ -65,12 +65,12 @@ interface FileStats {
     acronymCount: number;
 }
 
-function detectFormat(filePath: string): FileFormat | null {
+export function detectFormat(filePath: string): FileFormat | null {
     const ext = path.extname(filePath).toLowerCase();
     return SUPPORTED_EXTENSIONS.get(ext) ?? null;
 }
 
-function countSyllables(word: string): number {
+export function countSyllables(word: string): number {
     const w = word.toLowerCase().replace(/[^a-z]/g, '');
     if (w.length === 0) return 0;
     if (w.length <= 3) return 1;
@@ -87,14 +87,14 @@ function countSyllables(word: string): number {
     return Math.max(1, count);
 }
 
-function tokenize(text: string): Tokens {
+export function tokenize(text: string): Tokens {
     const sentences = text.split(/[.!?]+/).filter(s => s.trim().length > 0).length;
     const words = text.split(/\s+/).filter(Boolean);
     const syllableCounts = words.map(countSyllables);
     return { sentences, words, syllableCounts };
 }
 
-function fleschKincaid(tokens: Tokens): number {
+export function fleschKincaid(tokens: Tokens): number {
     const { words, syllableCounts } = tokens;
     if (words.length === 0) return 0;
     const sentenceCount = Math.max(tokens.sentences, 1);
@@ -105,7 +105,7 @@ function fleschKincaid(tokens: Tokens): number {
     return Math.max(0, Math.min(100, score));
 }
 
-function getRating(score: number): string {
+export function getRating(score: number): string {
     if (score >= 90) return '5th-6th grade level - Very easy to read.';
     if (score >= 80) return '7th grade level - Fairly easy to read.';
     if (score >= 70) return '8th & 9th grade - Plain English.';
@@ -115,7 +115,7 @@ function getRating(score: number): string {
     return 'Professional - Extremely difficult to read.';
 }
 
-function stripExistingHeader(content: string, format: FileFormat): string {
+export function stripExistingHeader(content: string, format: FileFormat): string {
     const startPattern = format === 'markdown'
         ? /<!--\s*readability-score:start\s*-->/
         : /\/\/\s*readability-score:start/;
@@ -131,7 +131,7 @@ function stripExistingHeader(content: string, format: FileFormat): string {
     return (content.slice(0, startMatch.index) + content.slice(cutEnd)).replace(/^\n+/, '');
 }
 
-function stripLegacyHeader(content: string): string {
+export function stripLegacyHeader(content: string): string {
     if (!/^\/\/ Readability score: \d/.test(content)) return content;
     const lines = content.split('\n');
     let i = 0;
@@ -140,7 +140,7 @@ function stripLegacyHeader(content: string): string {
     return lines.slice(i).join('\n');
 }
 
-function stripMarkdown(content: string): { cleaned: string; hasCodeBlock: boolean } {
+export function stripMarkdown(content: string): { cleaned: string; hasCodeBlock: boolean } {
     let text = content;
     let hasCodeBlock = false;
 
@@ -168,7 +168,7 @@ function stripMarkdown(content: string): { cleaned: string; hasCodeBlock: boolea
     return { cleaned: text.trim(), hasCodeBlock };
 }
 
-function stripAsciidoc(content: string): { cleaned: string; hasCodeBlock: boolean } {
+export function stripAsciidoc(content: string): { cleaned: string; hasCodeBlock: boolean } {
     let text = content;
     let hasCodeBlock = false;
 
@@ -194,12 +194,12 @@ function clean(content: string, format: FileFormat): { cleaned: string; hasCodeB
     return format === 'markdown' ? stripMarkdown(content) : stripAsciidoc(content);
 }
 
-function countAcronyms(text: string): number {
+export function countAcronyms(text: string): number {
     const matches = text.match(/\b[A-Z]{2,}\b/g);
     return matches ? matches.length : 0;
 }
 
-function formatHeader(stats: FileStats, format: FileFormat): string {
+export function formatHeader(stats: FileStats, format: FileFormat): string {
     const lines = [
         HEADER_START,
         `Readability score: ${stats.score.toFixed(2)}`,
@@ -310,7 +310,7 @@ interface CliArgs {
     whatsNew: boolean;
 }
 
-function parseArgs(argv: string[]): CliArgs {
+export function parseArgs(argv: string[]): CliArgs {
     const args = argv.slice(2);
     const dryRun = args.includes('--dry-run') || args.includes('-n');
     const help = args.includes('--help') || args.includes('-h');
@@ -323,7 +323,7 @@ function parseArgs(argv: string[]): CliArgs {
     return { folderPath, dryRun, help, version, whatsNew };
 }
 
-function printHelp(): void {
+export function printHelp(): void {
     console.log(
         'Usage: readability-ts [path] [options]\n\n' +
         'Computes Flesch-Kincaid readability scores for AsciiDoc and Markdown files.\n\n' +
@@ -343,11 +343,11 @@ function printHelp(): void {
     );
 }
 
-function printVersion(): void {
+export function printVersion(): void {
     console.log(`readability-ts v${VERSION}`);
 }
 
-function printWhatsNew(): void {
+export function printWhatsNew(): void {
     console.log(RELEASE_NOTES);
 }
 
@@ -416,4 +416,6 @@ async function main(): Promise<void> {
     }
 }
 
-void main();
+if (require.main === module) {
+    void main();
+}

--- a/readability.ts
+++ b/readability.ts
@@ -4,6 +4,28 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { performance } from 'perf_hooks';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkg = require('./package.json') as { version: string };
+const VERSION: string = pkg.version;
+
+const RELEASE_NOTES = `What's new in readability-ts v${VERSION}
+
+* Idempotent re-runs: existing readability headers are detected via
+  readability-score:start / readability-score:end sentinels and replaced
+  in place, so re-running the tool no longer stacks duplicate headers.
+* Legacy headers written by pre-0.9 versions are auto-migrated on the
+  next run.
+* Added --dry-run (-n): compute scores without modifying files or
+  writing scores.txt.
+* Added --version (-v) and --whats-new (--release-notes, -rn).
+* Default-skip vendored and build directories: node_modules, .git,
+  dist, build, out, .next, .nuxt, .cache, coverage, .idea, .vscode.
+* Concurrent processing (8 files at a time) and a TTY progress bar.
+
+For the full changelog see:
+https://github.com/alexneri/readability-folder-ts/commits/main
+`;
+
 type FileFormat = 'asciidoc' | 'markdown';
 
 const SUPPORTED_EXTENSIONS: ReadonlyMap<string, FileFormat> = new Map([
@@ -283,15 +305,21 @@ interface CliArgs {
     folderPath: string;
     dryRun: boolean;
     help: boolean;
+    version: boolean;
+    whatsNew: boolean;
 }
 
 function parseArgs(argv: string[]): CliArgs {
     const args = argv.slice(2);
     const dryRun = args.includes('--dry-run') || args.includes('-n');
     const help = args.includes('--help') || args.includes('-h');
+    const version = args.includes('--version') || args.includes('-v');
+    const whatsNew = args.includes('--whats-new')
+        || args.includes('--release-notes')
+        || args.includes('-rn');
     const positional = args.filter(a => !a.startsWith('-'));
     const folderPath = positional[0] || process.cwd();
-    return { folderPath, dryRun, help };
+    return { folderPath, dryRun, help, version, whatsNew };
 }
 
 function printHelp(): void {
@@ -299,20 +327,43 @@ function printHelp(): void {
         'Usage: readability-ts [path] [options]\n\n' +
         'Computes Flesch-Kincaid readability scores for AsciiDoc and Markdown files.\n\n' +
         'Arguments:\n' +
-        '  path           Folder to scan (defaults to current directory)\n\n' +
+        '  path                          Folder to scan (defaults to current directory)\n\n' +
         'Options:\n' +
-        '  -n, --dry-run  Compute scores without modifying files or writing scores.txt\n' +
-        '  -h, --help     Show this message\n\n' +
-        'Supported extensions: .adoc, .asciidoc, .md, .markdown, .mdx'
+        '  -n,  --dry-run                Compute scores without modifying files or writing scores.txt\n' +
+        '  -v,  --version                Print the installed version and exit\n' +
+        '  -rn, --whats-new,\n' +
+        '       --release-notes          Print release notes for the current version and exit\n' +
+        '  -h,  --help                   Show this message and exit\n\n' +
+        'Supported extensions: .adoc, .asciidoc, .md, .markdown, .mdx\n\n' +
+        'Examples:\n' +
+        '  readability-ts                Scan the current folder\n' +
+        '  readability-ts ./docs         Scan a specific folder\n' +
+        '  readability-ts ./docs -n      Preview scores without writing anything'
     );
+}
+
+function printVersion(): void {
+    console.log(`readability-ts v${VERSION}`);
+}
+
+function printWhatsNew(): void {
+    console.log(RELEASE_NOTES);
 }
 
 async function main(): Promise<void> {
     const start = performance.now();
-    const { folderPath, dryRun, help } = parseArgs(process.argv);
+    const { folderPath, dryRun, help, version, whatsNew } = parseArgs(process.argv);
 
     if (help) {
         printHelp();
+        return;
+    }
+    if (version) {
+        printVersion();
+        return;
+    }
+    if (whatsNew) {
+        printWhatsNew();
         return;
     }
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const CLI = path.join(__dirname, '..', 'readability.js');
+const pkg = require('../package.json');
+
+function run(args, opts = {}) {
+    return spawnSync(process.execPath, [CLI, ...args], {
+        encoding: 'utf-8',
+        ...opts,
+    });
+}
+
+function mkTempDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'readability-test-'));
+}
+
+test('--version prints "readability-ts v<version>" and exits 0', () => {
+    const r = run(['--version']);
+    assert.equal(r.status, 0);
+    assert.equal(r.stdout.trim(), `readability-ts v${pkg.version}`);
+});
+
+test('-v has the same output as --version', () => {
+    assert.equal(run(['-v']).stdout, run(['--version']).stdout);
+});
+
+test('--help prints usage and lists all flags', () => {
+    const r = run(['--help']);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /Usage: readability-ts/);
+    for (const flag of ['--dry-run', '--version', '--whats-new', '--release-notes', '--help']) {
+        assert.ok(r.stdout.includes(flag), `help output missing ${flag}`);
+    }
+});
+
+test('-h has the same output as --help', () => {
+    assert.equal(run(['-h']).stdout, run(['--help']).stdout);
+});
+
+test('--whats-new prints release notes and homepage', () => {
+    const r = run(['--whats-new']);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /What's new in readability-ts v/);
+    assert.ok(r.stdout.includes(pkg.version));
+    if (pkg.homepage) assert.ok(r.stdout.includes(pkg.homepage));
+});
+
+test('--release-notes and -rn match --whats-new', () => {
+    const baseline = run(['--whats-new']).stdout;
+    assert.equal(run(['--release-notes']).stdout, baseline);
+    assert.equal(run(['-rn']).stdout, baseline);
+});
+
+test('--dry-run on a temp folder computes scores without writing scores.txt or modifying files', () => {
+    const dir = mkTempDir();
+    try {
+        const sample = '# Title\n\nThis is some sample prose used to compute a readability score.\n';
+        const file = path.join(dir, 'sample.md');
+        fs.writeFileSync(file, sample);
+
+        const r = run([dir, '--dry-run']);
+        assert.equal(r.status, 0);
+        assert.match(r.stdout, /dry-run: no files were modified/);
+
+        assert.ok(!fs.existsSync(path.join(dir, 'scores.txt')), 'scores.txt should not be written');
+        assert.equal(fs.readFileSync(file, 'utf-8'), sample, 'source file should be unchanged');
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test('default run writes scores.txt and prepends a per-file header', () => {
+    const dir = mkTempDir();
+    try {
+        const sample = '# Title\n\nThis is some sample prose used to compute a readability score.\n';
+        const file = path.join(dir, 'sample.md');
+        fs.writeFileSync(file, sample);
+
+        const r = run([dir]);
+        assert.equal(r.status, 0);
+        assert.ok(fs.existsSync(path.join(dir, 'scores.txt')), 'scores.txt should be written');
+
+        const updated = fs.readFileSync(file, 'utf-8');
+        assert.match(updated, /<!-- readability-score:start -->/);
+        assert.match(updated, /<!-- readability-score:end -->/);
+        assert.ok(updated.endsWith(sample), 'original content should be preserved after the header');
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test('re-running on the same folder does not stack headers', () => {
+    const dir = mkTempDir();
+    try {
+        const sample = '# Title\n\nThis is sample prose for an idempotency test.\n';
+        const file = path.join(dir, 'sample.md');
+        fs.writeFileSync(file, sample);
+
+        run([dir]);
+        run([dir]);
+        const updated = fs.readFileSync(file, 'utf-8');
+        const startMatches = updated.match(/readability-score:start/g) || [];
+        assert.equal(startMatches.length, 1, 'should have exactly one start sentinel');
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test('exits 0 with a friendly message when no supported files are found', () => {
+    const dir = mkTempDir();
+    try {
+        fs.writeFileSync(path.join(dir, 'not-supported.txt'), 'hi');
+        const r = run([dir]);
+        assert.equal(r.status, 0);
+        assert.match(r.stdout, /No supported files found/);
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,0 +1,278 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    VERSION,
+    HOMEPAGE,
+    RELEASE_NOTES,
+    detectFormat,
+    countSyllables,
+    tokenize,
+    fleschKincaid,
+    getRating,
+    stripExistingHeader,
+    stripLegacyHeader,
+    stripMarkdown,
+    stripAsciidoc,
+    countAcronyms,
+    formatHeader,
+    parseArgs,
+    printHelp,
+    printVersion,
+    printWhatsNew,
+} = require('../readability.js');
+
+function captureStdout(fn) {
+    const original = console.log;
+    const lines = [];
+    console.log = (...args) => lines.push(args.map(String).join(' '));
+    try {
+        fn();
+    } finally {
+        console.log = original;
+    }
+    return lines.join('\n');
+}
+
+test('VERSION matches package.json', () => {
+    const pkg = require('../package.json');
+    assert.equal(VERSION, pkg.version);
+});
+
+test('HOMEPAGE matches package.json', () => {
+    const pkg = require('../package.json');
+    assert.equal(HOMEPAGE, pkg.homepage);
+});
+
+test('RELEASE_NOTES includes version and homepage', () => {
+    assert.match(RELEASE_NOTES, new RegExp(`v${VERSION}`));
+    assert.ok(HOMEPAGE === undefined || RELEASE_NOTES.includes(HOMEPAGE));
+});
+
+test('detectFormat returns the right format for each supported extension', () => {
+    assert.equal(detectFormat('foo.md'), 'markdown');
+    assert.equal(detectFormat('foo.markdown'), 'markdown');
+    assert.equal(detectFormat('foo.mdx'), 'markdown');
+    assert.equal(detectFormat('foo.adoc'), 'asciidoc');
+    assert.equal(detectFormat('foo.asciidoc'), 'asciidoc');
+    assert.equal(detectFormat('foo.MD'), 'markdown', 'extension match is case-insensitive');
+    assert.equal(detectFormat('foo.txt'), null);
+    assert.equal(detectFormat('README'), null);
+});
+
+test('countSyllables handles edge cases', () => {
+    assert.equal(countSyllables(''), 0);
+    assert.equal(countSyllables('a'), 1);
+    assert.equal(countSyllables('the'), 1, 'words <=3 chars are always 1');
+    assert.equal(countSyllables('hello'), 2);
+    assert.equal(countSyllables('readability'), 5);
+    assert.equal(countSyllables('123'), 0, 'non-letters strip to empty -> 0');
+    assert.equal(countSyllables('MAKE'), 1, 'silent trailing e drops a syllable but min is 1');
+});
+
+test('tokenize counts sentences and words', () => {
+    const t = tokenize('Hello world. This is a test! Is it?');
+    assert.equal(t.sentences, 3);
+    assert.equal(t.words.length, 8);
+    assert.equal(t.syllableCounts.length, 8);
+});
+
+test('fleschKincaid returns 0 for empty input', () => {
+    assert.equal(fleschKincaid({ sentences: 0, words: [], syllableCounts: [] }), 0);
+});
+
+test('fleschKincaid is bounded to [0,100]', () => {
+    const easy = tokenize('The cat sat on the mat. The dog ran.');
+    const s = fleschKincaid(easy);
+    assert.ok(s >= 0 && s <= 100, `score ${s} out of range`);
+});
+
+test('getRating bucket boundaries', () => {
+    assert.match(getRating(95), /5th-6th grade/);
+    assert.match(getRating(85), /7th grade/);
+    assert.match(getRating(75), /8th & 9th grade/);
+    assert.match(getRating(65), /10th-12th grade/);
+    assert.match(getRating(55), /College - Difficult/);
+    assert.match(getRating(40), /College grad/);
+    assert.match(getRating(10), /Professional/);
+});
+
+test('stripExistingHeader is idempotent for markdown', () => {
+    const body = '# Hello\n\nSome content.\n';
+    const wrapped =
+        '<!-- readability-score:start -->\n' +
+        '<!-- Readability score: 70 -->\n' +
+        '<!-- 8th & 9th grade - Plain English. -->\n' +
+        '<!-- readability-score:end -->\n\n' +
+        body;
+    assert.equal(stripExistingHeader(wrapped, 'markdown'), body);
+    assert.equal(stripExistingHeader(body, 'markdown'), body, 'no-op on un-headered content');
+});
+
+test('stripExistingHeader is idempotent for asciidoc', () => {
+    const body = '= Hello\n\nSome content.\n';
+    const wrapped =
+        '// readability-score:start\n' +
+        '// Readability score: 70\n' +
+        '// readability-score:end\n\n' +
+        body;
+    assert.equal(stripExistingHeader(wrapped, 'asciidoc'), body);
+});
+
+test('stripLegacyHeader removes pre-0.9 headers', () => {
+    const legacy = '// Readability score: 65.42\n// Plain English.\n// Word count: 10\n\nBody text here.';
+    const cleaned = stripLegacyHeader(legacy);
+    assert.equal(cleaned, 'Body text here.');
+});
+
+test('stripLegacyHeader leaves non-matching content alone', () => {
+    const content = '// This is just a comment\nMore content.';
+    assert.equal(stripLegacyHeader(content), content);
+});
+
+test('stripMarkdown strips code fences and reports presence', () => {
+    const input = '# Title\n\nProse.\n\n```\ncode here\n```\n\nMore prose.';
+    const { cleaned, hasCodeBlock } = stripMarkdown(input);
+    assert.equal(hasCodeBlock, true);
+    assert.ok(!cleaned.includes('code here'));
+    assert.ok(cleaned.includes('Prose.'));
+});
+
+test('stripMarkdown strips frontmatter, links, and emphasis', () => {
+    const input = '---\ntitle: x\n---\n# H\n\nText with **bold** and [a link](https://example.com).';
+    const { cleaned } = stripMarkdown(input);
+    assert.ok(!cleaned.includes('title:'));
+    assert.ok(!cleaned.includes('https://example.com'));
+    assert.ok(cleaned.includes('bold'));
+    assert.ok(cleaned.includes('a link'));
+});
+
+test('stripMarkdown reports no code block when none is present', () => {
+    const { hasCodeBlock } = stripMarkdown('# H\n\nJust prose, no fences.');
+    assert.equal(hasCodeBlock, false);
+});
+
+test('stripAsciidoc strips dashed code blocks and headings', () => {
+    const input = '= Heading\n\nProse.\n\n----\ncode\n----\n\nMore.';
+    const { cleaned, hasCodeBlock } = stripAsciidoc(input);
+    assert.equal(hasCodeBlock, true);
+    assert.ok(!cleaned.includes('code'));
+    assert.ok(cleaned.includes('Prose.'));
+});
+
+test('stripAsciidoc strips emphasis markers', () => {
+    const { cleaned } = stripAsciidoc('Text with *bold* and _italic_ words.');
+    assert.ok(cleaned.includes('bold'));
+    assert.ok(cleaned.includes('italic'));
+    assert.ok(!cleaned.includes('*bold*'));
+    assert.ok(!cleaned.includes('_italic_'));
+});
+
+test('countAcronyms counts 2+ uppercase letter runs', () => {
+    assert.equal(countAcronyms('Using API and HTTP today'), 2);
+    assert.equal(countAcronyms('No acronyms here'), 0);
+    assert.equal(countAcronyms('USA NASA NATO'), 3);
+    assert.equal(countAcronyms('A B C'), 0, 'single uppercase letters do not count');
+});
+
+test('formatHeader wraps markdown header in HTML comments', () => {
+    const stats = {
+        score: 70.5,
+        rating: '8th & 9th grade - Plain English.',
+        lineCount: 10,
+        sentenceCount: 5,
+        wordCount: 50,
+        avgWordLength: 4.2,
+        avgSyllables: 1.5,
+        hasCodeBlock: false,
+        acronymCount: 2,
+    };
+    const out = formatHeader(stats, 'markdown');
+    assert.match(out, /^<!-- readability-score:start -->/);
+    assert.ok(out.includes('<!-- readability-score:end -->'));
+    assert.ok(out.includes('Readability score: 70.50'));
+    assert.ok(!out.includes('// readability-score:start'));
+});
+
+test('formatHeader wraps asciidoc header in // comments', () => {
+    const stats = {
+        score: 70.5,
+        rating: 'Plain English.',
+        lineCount: 1,
+        sentenceCount: 1,
+        wordCount: 1,
+        avgWordLength: 1,
+        avgSyllables: 1,
+        hasCodeBlock: true,
+        acronymCount: 0,
+    };
+    const out = formatHeader(stats, 'asciidoc');
+    assert.match(out, /^\/\/ readability-score:start/);
+    assert.ok(out.includes('Code present: Yes'));
+    assert.ok(!out.includes('<!--'));
+});
+
+test('parseArgs defaults', () => {
+    const args = parseArgs(['node', 'readability.js']);
+    assert.equal(args.folderPath, process.cwd());
+    assert.equal(args.dryRun, false);
+    assert.equal(args.help, false);
+    assert.equal(args.version, false);
+    assert.equal(args.whatsNew, false);
+});
+
+test('parseArgs positional path', () => {
+    const args = parseArgs(['node', 'readability.js', './docs']);
+    assert.equal(args.folderPath, './docs');
+});
+
+test('parseArgs --dry-run and -n', () => {
+    assert.equal(parseArgs(['n', 's', '--dry-run']).dryRun, true);
+    assert.equal(parseArgs(['n', 's', '-n']).dryRun, true);
+});
+
+test('parseArgs --version and -v', () => {
+    assert.equal(parseArgs(['n', 's', '--version']).version, true);
+    assert.equal(parseArgs(['n', 's', '-v']).version, true);
+});
+
+test('parseArgs --help and -h', () => {
+    assert.equal(parseArgs(['n', 's', '--help']).help, true);
+    assert.equal(parseArgs(['n', 's', '-h']).help, true);
+});
+
+test('parseArgs --whats-new, --release-notes, -rn all map to whatsNew', () => {
+    assert.equal(parseArgs(['n', 's', '--whats-new']).whatsNew, true);
+    assert.equal(parseArgs(['n', 's', '--release-notes']).whatsNew, true);
+    assert.equal(parseArgs(['n', 's', '-rn']).whatsNew, true);
+});
+
+test('parseArgs combines flags with positional path', () => {
+    const args = parseArgs(['n', 's', '--dry-run', './docs']);
+    assert.equal(args.folderPath, './docs');
+    assert.equal(args.dryRun, true);
+});
+
+test('printVersion prints "readability-ts v<version>"', () => {
+    const out = captureStdout(printVersion);
+    assert.equal(out, `readability-ts v${VERSION}`);
+});
+
+test('printHelp lists all flags', () => {
+    const out = captureStdout(printHelp);
+    assert.match(out, /Usage: readability-ts/);
+    assert.match(out, /--dry-run/);
+    assert.match(out, /--version/);
+    assert.match(out, /--whats-new/);
+    assert.match(out, /--release-notes/);
+    assert.match(out, /--help/);
+});
+
+test('printWhatsNew prints release notes including version', () => {
+    const out = captureStdout(printWhatsNew);
+    assert.match(out, /What's new in readability-ts v/);
+    assert.ok(out.includes(VERSION));
+    if (HOMEPAGE) assert.ok(out.includes(HOMEPAGE));
+});


### PR DESCRIPTION
## Summary

Adds two new CLI flag families, refreshes the existing `--help` output, points `--whats-new` at the canonical project homepage, and lands an initial automated test suite.

### CLI changes
- `-v`, `--version` — prints the installed version. The value is sourced from `package.json` at runtime so it stays in sync when the package version is bumped.
- `-rn`, `--whats-new`, `--release-notes` — prints inline release notes for the current version. All three spellings are accepted. The output ends with a "Find out more: <homepage>" line sourced from `package.json`'s `homepage` field.
- `-h`, `--help` — already existed; the message is updated to list the new flags, separate short and long forms in two columns, and include a short Examples block.

### Repo changes
- `package.json` `homepage` field is updated to `https://readability-cli.sei.moe/` (the canonical project site). GitHub URLs for clone, issues, and the commits-based changelog link in the release notes intentionally stay GitHub-specific.
- `README.md` Usage section is updated to match, plus a new Development section.

### Test suite (new)
- `test/unit.test.js` — 30 unit tests covering `parseArgs` (every flag variant), `printHelp`/`printVersion`/`printWhatsNew` output, `countSyllables`, `tokenize`, `fleschKincaid`, `getRating`, `stripMarkdown`, `stripAsciidoc`, `stripExistingHeader`, `stripLegacyHeader`, `countAcronyms`, `formatHeader`, `detectFormat`, and the `VERSION`/`HOMEPAGE`/`RELEASE_NOTES` constants.
- `test/cli.test.js` — 11 integration tests that spawn the CLI in a child process and assert exit codes, output, and side effects (`scores.txt` creation, per-file header injection, idempotent re-runs, dry-run no-op, friendly message when no supported files are found).
- The pure functions and constants are now `export`ed from `readability.ts` so tests can import them. `main()` is gated behind `require.main === module` so importing the module no longer triggers a folder scan.
- New `test` script (`node --test test/*.test.js`) using Node 18+'s built-in `node:test`. **No new devDependencies.**
- `prepublishOnly` is now gated on the suite passing.

Flag-checking order in `main()` is `--help` → `--version` → `--whats-new`; first match wins and the program exits before scanning any files.

## Test plan

- [x] `npm test` — 41/41 passing
- [x] `node readability.js --version` and `-v` print `readability-ts v0.9.0`
- [x] `node readability.js --whats-new`, `--release-notes`, and `-rn` all print the same release notes, ending in `Find out more: https://readability-cli.sei.moe/`
- [x] `node readability.js --help` and `-h` print the refreshed usage including the new flags
- [x] `node readability.js <folder>` still writes `scores.txt` and the per-file header
- [x] `node readability.js <folder> --dry-run` still computes scores without touching files
- [x] `tsc` build is clean

## Follow-up

The site at `https://readability-cli.sei.moe/` needs to be brought up to date to match the new CLI surface (new flags + 0.9.0 release notes). That work happens in a separate session against the website repo.